### PR TITLE
Remove exit from iOS code

### DIFF
--- a/ios/ReactNativeShareExtension.m
+++ b/ios/ReactNativeShareExtension.m
@@ -39,7 +39,6 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(close) {
     [extensionContext completeRequestReturningItems:nil
                                   completionHandler:nil];
-    exit(0);
 }
 
 RCT_EXPORT_METHOD(openURL:(NSString *)url) {


### PR DESCRIPTION
exit was causing the extension to close before the JavaScript code was executed, but only when the app was archived